### PR TITLE
fix for single result

### DIFF
--- a/lib/pardot/query.rb
+++ b/lib/pardot/query.rb
@@ -6,6 +6,7 @@ module Pardot
       response = get(object, path, params)
       result = response["result"]
       result["total_results"] = result["total_results"].to_i if result["total_results"]
+      result[object] = [result[object]] if result[object].is_a?(Hash)
       result
     end
 

--- a/lib/pardot/query.rb
+++ b/lib/pardot/query.rb
@@ -4,11 +4,27 @@ module Pardot
     def query(object, params)
       path = '/do/query/'
       response = get(object, path, params)
-      result = response["result"]
+      result = process_result(response["result"], object)
+      result
+    end
+
+    def process_result(result, object)
       result["total_results"] = result["total_results"].to_i if result["total_results"]
+      result = result.map{ |k, v| [rename_data_key(object, k), v] }.to_h
       result[object] = [result[object]] if result[object].is_a?(Hash)
       result
     end
 
+    def rename_data_key(object, key)
+      if clean_key(object) == clean_key(key)
+        return object
+      else
+        return key
+      end
+    end
+
+    def clean_key(key)
+      key.gsub('_', '').downcase
+    end
   end
 end


### PR DESCRIPTION
when a query result is just one record, the api returns a hash instead of an array. to make query results easier to handle, this makes sure the result is always an array.

also adding a fix where results from some endpounts come back with camel case names and others with snake case names. i'm converting them all to camel case key names to match their URL endpoints.