### PR TITLE
fix/refactor http retries

### DIFF
--- a/lib/pardot/http.rb
+++ b/lib/pardot/http.rb
@@ -1,70 +1,71 @@
 module Pardot
   module Http
-    
-    def get object, path, params = {}, num_retries = 0
-      smooth_params object, params
-      full_path = fullpath object, path
-      check_response self.class.get(full_path, :query => params)
-      
-    rescue Pardot::ExpiredApiKeyError => e
-      handle_expired_api_key :get, object, path, params, num_retries, e
-      
-    rescue SocketError, Interrupt, EOFError, SystemCallError, Timeout::Error, MultiXml::ParseError => e
-      raise Pardot::NetError.new(e)
+
+    def get(object, path, params = {}, num_retries = 0)
+      request(:get, object, path, params = params, max_retries = num_retries)
     end
-    
-    def post object, path, params = {}, num_retries = 0
-      smooth_params object, params
-      full_path = fullpath object, path
-      check_response self.class.post(full_path, :query => params)
-      
-    rescue Pardot::ExpiredApiKeyError => e
-      handle_expired_api_key :post, object, path, params, num_retries, e
-      
-    rescue SocketError, Interrupt, EOFError, SystemCallError, Timeout::Error, MultiXml::ParseError => e
-      raise Pardot::NetError.new(e)
+
+    def post(object, path, params = {}, num_retries = 0)
+      request(:post, object, path, params = params, max_retries = num_retries)
     end
-    
+
     protected
-    
-    def handle_expired_api_key method, object, path, params, num_retries, e
-      raise e unless num_retries == 0
-      
-      reauthenticate
-      
-      send(method, object, path, params, 1)
+
+    def request(method, object, path, params = {}, max_retries = 0)
+      tries_remaining ||= max_retries
+      smooth_params(object, params)
+      full_path = fullpath(object, path)
+      check_response(self.class.send(method, full_path, :query => params))
+
+    # handle errors that should be retried:
+    # exponential backoff/retry for timeout errors
+    # reauthenticate/retry for expired API key
+    rescue Pardot::ExpiredApiKeyError, Net::ReadTimeout => e
+      if (tries_remaining -= 1) > 0
+        if e.message.include?("ExpiredApiKey")
+          reauthenticate
+        else
+          sleep(2 ** (max_retries - tries_remaining))
+        end
+        retry
+      else
+        raise Pardot::NetError.new(e)
+      end
+
+    rescue SocketError, Interrupt, EOFError, SystemCallError, Timeout::Error, MultiXml::ParseError => e
+      raise Pardot::NetError.new(e)
     end
-    
-    def smooth_params object, params
+
+    def smooth_params(object, params)
       return if object == "login"
-      
+
       authenticate unless authenticated?
       params.merge! :user_key => @user_key, :api_key => @api_key, :format => @format
     end
-    
-    def check_response http_response
+
+    def check_response(http_response)
       rsp = http_response["rsp"]
-      
+
       error = rsp["err"] if rsp
       error ||= "Unknown Failure: #{rsp.inspect}" if rsp && rsp["stat"] == "fail"
       content = error['__content__'] if error.is_a?(Hash)
-      
+
       if [error, content].include?("Invalid API key or user key") && @api_key
         raise ExpiredApiKeyError.new @api_key
       end
-      
+
       raise ResponseError.new error if error
-      
+
       rsp
     end
-    
-    def fullpath object, path
+
+    def fullpath(object, path)
       full = File.join("/api", object, "version", @version.to_s)
       unless path.nil?
         full = File.join(full, path)
       end
       full
     end
-    
+
   end
 end

--- a/lib/pardot/query.rb
+++ b/lib/pardot/query.rb
@@ -1,9 +1,9 @@
 module Pardot
   module Query
 
-    def query(object, params)
+    def query(object, params, retries=3)
       path = '/do/query/'
-      response = get(object, path, params)
+      response = get(object, path, params, num_retries=retries)
       result = process_result(response["result"], object)
       result
     end


### PR DESCRIPTION
what's happening:
- fixes and refactors logic for retrying requests that fail because of timeouts or expired API keys
- sets the default to 3 retry attempts for queries
- adds a single request method to handle both gets and posts and take the method as a param, bc the separate get/post methods were basically identical
- some cleanup